### PR TITLE
Import flask_sqlalchemy directly

### DIFF
--- a/flask_whooshalchemy.py
+++ b/flask_whooshalchemy.py
@@ -15,7 +15,7 @@ from __future__ import with_statement
 from __future__ import absolute_import
 
 
-import flask.ext.sqlalchemy as flask_sqlalchemy
+import flask_sqlalchemy
 
 import sqlalchemy
 


### PR DESCRIPTION
Instead of using the deprecated `flask.ext` import, import flask_sqlalchemy directly.
